### PR TITLE
Add WebRTC live streaming session generation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1867,6 +1867,101 @@ docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "s
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
 
 [[package]]
+name = "websockets"
+version = "13.0.1"
+description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "websockets-13.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1841c9082a3ba4a05ea824cf6d99570a6a2d8849ef0db16e9c826acb28089e8f"},
+    {file = "websockets-13.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c5870b4a11b77e4caa3937142b650fbbc0914a3e07a0cf3131f35c0587489c1c"},
+    {file = "websockets-13.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f1d3d1f2eb79fe7b0fb02e599b2bf76a7619c79300fc55f0b5e2d382881d4f7f"},
+    {file = "websockets-13.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15c7d62ee071fa94a2fc52c2b472fed4af258d43f9030479d9c4a2de885fd543"},
+    {file = "websockets-13.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6724b554b70d6195ba19650fef5759ef11346f946c07dbbe390e039bcaa7cc3d"},
+    {file = "websockets-13.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56a952fa2ae57a42ba7951e6b2605e08a24801a4931b5644dfc68939e041bc7f"},
+    {file = "websockets-13.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:17118647c0ea14796364299e942c330d72acc4b248e07e639d34b75067b3cdd8"},
+    {file = "websockets-13.0.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:64a11aae1de4c178fa653b07d90f2fb1a2ed31919a5ea2361a38760192e1858b"},
+    {file = "websockets-13.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:0617fd0b1d14309c7eab6ba5deae8a7179959861846cbc5cb528a7531c249448"},
+    {file = "websockets-13.0.1-cp310-cp310-win32.whl", hash = "sha256:11f9976ecbc530248cf162e359a92f37b7b282de88d1d194f2167b5e7ad80ce3"},
+    {file = "websockets-13.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:c3c493d0e5141ec055a7d6809a28ac2b88d5b878bb22df8c621ebe79a61123d0"},
+    {file = "websockets-13.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:699ba9dd6a926f82a277063603fc8d586b89f4cb128efc353b749b641fcddda7"},
+    {file = "websockets-13.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cf2fae6d85e5dc384bf846f8243ddaa9197f3a1a70044f59399af001fd1f51d4"},
+    {file = "websockets-13.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:52aed6ef21a0f1a2a5e310fb5c42d7555e9c5855476bbd7173c3aa3d8a0302f2"},
+    {file = "websockets-13.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8eb2b9a318542153674c6e377eb8cb9ca0fc011c04475110d3477862f15d29f0"},
+    {file = "websockets-13.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5df891c86fe68b2c38da55b7aea7095beca105933c697d719f3f45f4220a5e0e"},
+    {file = "websockets-13.0.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fac2d146ff30d9dd2fcf917e5d147db037a5c573f0446c564f16f1f94cf87462"},
+    {file = "websockets-13.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b8ac5b46fd798bbbf2ac6620e0437c36a202b08e1f827832c4bf050da081b501"},
+    {file = "websockets-13.0.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:46af561eba6f9b0848b2c9d2427086cabadf14e0abdd9fde9d72d447df268418"},
+    {file = "websockets-13.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b5a06d7f60bc2fc378a333978470dfc4e1415ee52f5f0fce4f7853eb10c1e9df"},
+    {file = "websockets-13.0.1-cp311-cp311-win32.whl", hash = "sha256:556e70e4f69be1082e6ef26dcb70efcd08d1850f5d6c5f4f2bcb4e397e68f01f"},
+    {file = "websockets-13.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:67494e95d6565bf395476e9d040037ff69c8b3fa356a886b21d8422ad86ae075"},
+    {file = "websockets-13.0.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f9c9e258e3d5efe199ec23903f5da0eeaad58cf6fccb3547b74fd4750e5ac47a"},
+    {file = "websockets-13.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:6b41a1b3b561f1cba8321fb32987552a024a8f67f0d05f06fcf29f0090a1b956"},
+    {file = "websockets-13.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f73e676a46b0fe9426612ce8caeca54c9073191a77c3e9d5c94697aef99296af"},
+    {file = "websockets-13.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f613289f4a94142f914aafad6c6c87903de78eae1e140fa769a7385fb232fdf"},
+    {file = "websockets-13.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0f52504023b1480d458adf496dc1c9e9811df4ba4752f0bc1f89ae92f4f07d0c"},
+    {file = "websockets-13.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:139add0f98206cb74109faf3611b7783ceafc928529c62b389917a037d4cfdf4"},
+    {file = "websockets-13.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:47236c13be337ef36546004ce8c5580f4b1150d9538b27bf8a5ad8edf23ccfab"},
+    {file = "websockets-13.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c44ca9ade59b2e376612df34e837013e2b273e6c92d7ed6636d0556b6f4db93d"},
+    {file = "websockets-13.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9bbc525f4be3e51b89b2a700f5746c2a6907d2e2ef4513a8daafc98198b92237"},
+    {file = "websockets-13.0.1-cp312-cp312-win32.whl", hash = "sha256:3624fd8664f2577cf8de996db3250662e259bfbc870dd8ebdcf5d7c6ac0b5185"},
+    {file = "websockets-13.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0513c727fb8adffa6d9bf4a4463b2bade0186cbd8c3604ae5540fae18a90cb99"},
+    {file = "websockets-13.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1ee4cc030a4bdab482a37462dbf3ffb7e09334d01dd37d1063be1136a0d825fa"},
+    {file = "websockets-13.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:dbb0b697cc0655719522406c059eae233abaa3243821cfdfab1215d02ac10231"},
+    {file = "websockets-13.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:acbebec8cb3d4df6e2488fbf34702cbc37fc39ac7abf9449392cefb3305562e9"},
+    {file = "websockets-13.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63848cdb6fcc0bf09d4a155464c46c64ffdb5807ede4fb251da2c2692559ce75"},
+    {file = "websockets-13.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:872afa52a9f4c414d6955c365b6588bc4401272c629ff8321a55f44e3f62b553"},
+    {file = "websockets-13.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:05e70fec7c54aad4d71eae8e8cab50525e899791fc389ec6f77b95312e4e9920"},
+    {file = "websockets-13.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e82db3756ccb66266504f5a3de05ac6b32f287faacff72462612120074103329"},
+    {file = "websockets-13.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4e85f46ce287f5c52438bb3703d86162263afccf034a5ef13dbe4318e98d86e7"},
+    {file = "websockets-13.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f3fea72e4e6edb983908f0db373ae0732b275628901d909c382aae3b592589f2"},
+    {file = "websockets-13.0.1-cp313-cp313-win32.whl", hash = "sha256:254ecf35572fca01a9f789a1d0f543898e222f7b69ecd7d5381d8d8047627bdb"},
+    {file = "websockets-13.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:ca48914cdd9f2ccd94deab5bcb5ac98025a5ddce98881e5cce762854a5de330b"},
+    {file = "websockets-13.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:b74593e9acf18ea5469c3edaa6b27fa7ecf97b30e9dabd5a94c4c940637ab96e"},
+    {file = "websockets-13.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:132511bfd42e77d152c919147078460c88a795af16b50e42a0bd14f0ad71ddd2"},
+    {file = "websockets-13.0.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:165bedf13556f985a2aa064309baa01462aa79bf6112fbd068ae38993a0e1f1b"},
+    {file = "websockets-13.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e801ca2f448850685417d723ec70298feff3ce4ff687c6f20922c7474b4746ae"},
+    {file = "websockets-13.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30d3a1f041360f029765d8704eae606781e673e8918e6b2c792e0775de51352f"},
+    {file = "websockets-13.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67648f5e50231b5a7f6d83b32f9c525e319f0ddc841be0de64f24928cd75a603"},
+    {file = "websockets-13.0.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:4f0426d51c8f0926a4879390f53c7f5a855e42d68df95fff6032c82c888b5f36"},
+    {file = "websockets-13.0.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:ef48e4137e8799998a343706531e656fdec6797b80efd029117edacb74b0a10a"},
+    {file = "websockets-13.0.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:249aab278810bee585cd0d4de2f08cfd67eed4fc75bde623be163798ed4db2eb"},
+    {file = "websockets-13.0.1-cp38-cp38-win32.whl", hash = "sha256:06c0a667e466fcb56a0886d924b5f29a7f0886199102f0a0e1c60a02a3751cb4"},
+    {file = "websockets-13.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1f3cf6d6ec1142412d4535adabc6bd72a63f5f148c43fe559f06298bc21953c9"},
+    {file = "websockets-13.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:1fa082ea38d5de51dd409434edc27c0dcbd5fed2b09b9be982deb6f0508d25bc"},
+    {file = "websockets-13.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4a365bcb7be554e6e1f9f3ed64016e67e2fa03d7b027a33e436aecf194febb63"},
+    {file = "websockets-13.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:10a0dc7242215d794fb1918f69c6bb235f1f627aaf19e77f05336d147fce7c37"},
+    {file = "websockets-13.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:59197afd478545b1f73367620407b0083303569c5f2d043afe5363676f2697c9"},
+    {file = "websockets-13.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d20516990d8ad557b5abeb48127b8b779b0b7e6771a265fa3e91767596d7d97"},
+    {file = "websockets-13.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a1a2e272d067030048e1fe41aa1ec8cfbbaabce733b3d634304fa2b19e5c897f"},
+    {file = "websockets-13.0.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:ad327ac80ba7ee61da85383ca8822ff808ab5ada0e4a030d66703cc025b021c4"},
+    {file = "websockets-13.0.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:518f90e6dd089d34eaade01101fd8a990921c3ba18ebbe9b0165b46ebff947f0"},
+    {file = "websockets-13.0.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:68264802399aed6fe9652e89761031acc734fc4c653137a5911c2bfa995d6d6d"},
+    {file = "websockets-13.0.1-cp39-cp39-win32.whl", hash = "sha256:a5dc0c42ded1557cc7c3f0240b24129aefbad88af4f09346164349391dea8e58"},
+    {file = "websockets-13.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:b448a0690ef43db5ef31b3a0d9aea79043882b4632cfc3eaab20105edecf6097"},
+    {file = "websockets-13.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:faef9ec6354fe4f9a2c0bbb52fb1ff852effc897e2a4501e25eb3a47cb0a4f89"},
+    {file = "websockets-13.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:03d3f9ba172e0a53e37fa4e636b86cc60c3ab2cfee4935e66ed1d7acaa4625ad"},
+    {file = "websockets-13.0.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d450f5a7a35662a9b91a64aefa852f0c0308ee256122f5218a42f1d13577d71e"},
+    {file = "websockets-13.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3f55b36d17ac50aa8a171b771e15fbe1561217510c8768af3d546f56c7576cdc"},
+    {file = "websockets-13.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14b9c006cac63772b31abbcd3e3abb6228233eec966bf062e89e7fa7ae0b7333"},
+    {file = "websockets-13.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:b79915a1179a91f6c5f04ece1e592e2e8a6bd245a0e45d12fd56b2b59e559a32"},
+    {file = "websockets-13.0.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:f40de079779acbcdbb6ed4c65af9f018f8b77c5ec4e17a4b737c05c2db554491"},
+    {file = "websockets-13.0.1-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:80e4ba642fc87fa532bac07e5ed7e19d56940b6af6a8c61d4429be48718a380f"},
+    {file = "websockets-13.0.1-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2a02b0161c43cc9e0232711eff846569fad6ec836a7acab16b3cf97b2344c060"},
+    {file = "websockets-13.0.1-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6aa74a45d4cdc028561a7d6ab3272c8b3018e23723100b12e58be9dfa5a24491"},
+    {file = "websockets-13.0.1-pp38-pypy38_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00fd961943b6c10ee6f0b1130753e50ac5dcd906130dcd77b0003c3ab797d026"},
+    {file = "websockets-13.0.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:d93572720d781331fb10d3da9ca1067817d84ad1e7c31466e9f5e59965618096"},
+    {file = "websockets-13.0.1-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:71e6e5a3a3728886caee9ab8752e8113670936a193284be9d6ad2176a137f376"},
+    {file = "websockets-13.0.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:c4a6343e3b0714e80da0b0893543bf9a5b5fa71b846ae640e56e9abc6fbc4c83"},
+    {file = "websockets-13.0.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1a678532018e435396e37422a95e3ab87f75028ac79570ad11f5bf23cd2a7d8c"},
+    {file = "websockets-13.0.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d6716c087e4aa0b9260c4e579bb82e068f84faddb9bfba9906cb87726fa2e870"},
+    {file = "websockets-13.0.1-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e33505534f3f673270dd67f81e73550b11de5b538c56fe04435d63c02c3f26b5"},
+    {file = "websockets-13.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:acab3539a027a85d568c2573291e864333ec9d912675107d6efceb7e2be5d980"},
+    {file = "websockets-13.0.1-py3-none-any.whl", hash = "sha256:b80f0c51681c517604152eb6a572f5a9378f877763231fddb883ba2f968e8817"},
+    {file = "websockets-13.0.1.tar.gz", hash = "sha256:4d6ece65099411cfd9a48d13701d7438d9c34f479046b34c50ff60bb8834e43e"},
+]
+
+[[package]]
 name = "yarl"
 version = "1.9.7"
 description = "Yet another URL library"
@@ -1997,4 +2092,4 @@ listen = ["firebase-messaging"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "3ba1c88b5fb933f3cbdea18470a4fa2397e66759a5ea001347ee14f2e0e4294c"
+content-hash = "1b60f4ab2d60ff9b1b1bbb523a2902004c73531433a64d261ecaa18ff13d3a45"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,9 @@ filterwarnings = [
 [tool.coverage.run]
 source = ["ring_doorbell"]
 branch = true
+omit = [
+    "ring_doorbell/rtcstream.py"
+]
 
 [tool.ruff]
 target-version = "py39"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,9 +88,7 @@ filterwarnings = [
 [tool.coverage.run]
 source = ["ring_doorbell"]
 branch = true
-omit = [
-    "ring_doorbell/rtcstream.py"
-]
+omit = ["ring_doorbell/rtcstream.py*"]
 
 [tool.ruff]
 target-version = "py39"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ myst-parser = { version = "*", optional = true }
 firebase-messaging = {version = "^0.4.0", optional = true}
 typing-extensions = ">=4.12.2,<5.0"
 async-timeout = ">=3.0.0"
+websockets = ">=11.0.1"
 
 [tool.poetry.group.dev.dependencies]
 mock = "*"

--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -66,6 +66,7 @@ DEFAULT_VIDEO_DOWNLOAD_TIMEOUT = 120
 # API endpoints
 API_VERSION = "11"
 API_URI = "https://api.ring.com"
+APP_API_URI = "https://prd-api-us.prd.rings.solutions"
 USER_AGENT = "android:com.ringapp"
 
 # random uuid, used to make a hardware id that doesn't change or clash
@@ -112,6 +113,10 @@ INTERCOM_OPEN_ENDPOINT = "/commands/v1/devices/{0}/device_rpc"
 INTERCOM_INVITATIONS_ENDPOINT = LOCATIONS_ENDPOINT + "/invitations"
 INTERCOM_INVITATIONS_DELETE_ENDPOINT = LOCATIONS_ENDPOINT + "/invitations/{1}"
 INTERCOM_ALLOWED_USERS = LOCATIONS_ENDPOINT + "/users"
+
+# New API endpoints for web rtc streaming
+RTC_STREAMING_TICKET_ENDPOINT = "/api/v1/clap/ticket/request/signalsocket"
+RTC_STREAMING_WEB_SOCKET_ENDPOINT = "wss://api.prod.signalling.ring.devices.a2z.com:443/ws?api_version=4.0&auth_type=ring_solutions&client_id=ring_site-{0}&token={1}"
 
 KIND_DING = "ding"
 KIND_MOTION = "motion"
@@ -237,3 +242,14 @@ PERSIST_TOKEN_DATA = {
     "device[metadata][architecture]": "x86",
     "device[metadata][language]": "en",
 }
+
+ICE_SERVERS = [
+    "stun:stun.kinesisvideo.us-east-1.amazonaws.com:443",
+    "stun:stun.kinesisvideo.us-east-2.amazonaws.com:443",
+    "stun:stun.kinesisvideo.us-west-2.amazonaws.com:443",
+    "stun:stun.l.google.com:19302",
+    "stun:stun1.l.google.com:19302",
+    "stun:stun2.l.google.com:19302",
+    "stun:stun3.l.google.com:19302",
+    "stun:stun4.l.google.com:19302",
+]

--- a/ring_doorbell/ring.py
+++ b/ring_doorbell/ring.py
@@ -145,11 +145,14 @@ class Ring:
         data: bytes | None = None,
         json: dict[Any, Any] | None = None,
         timeout: float | None = None,
+        base_uri: str = API_URI,
     ) -> Auth.Response:
         """Query data from Ring API."""
         if self.session is None:
             await self.async_create_session()
-        return await self._async_query(url, method, extra_params, data, json, timeout)
+        return await self._async_query(
+            url, method, extra_params, data, json, timeout, base_uri
+        )
 
     async def _async_query(  # noqa: PLR0913
         self,
@@ -159,6 +162,7 @@ class Ring:
         data: bytes | None = None,
         json: dict[Any, Any] | None = None,
         timeout: float | None = None,
+        base_uri: str = API_URI,
     ) -> Auth.Response:
         _logger.debug(
             "url: %s\nmethod: %s\njson: %s\ndata: %s\n extra_params: %s",
@@ -168,16 +172,14 @@ class Ring:
             data,
             extra_params,
         )
-        response = await self.auth.async_query(
-            API_URI + url,
+        return await self.auth.async_query(
+            base_uri + url,
             method=method,
             extra_params=extra_params,
             data=data,
             json=json,
             timeout=timeout,
         )
-        _logger.debug("response_text %s", response.text)
-        return response
 
     def devices(self) -> RingDevices:
         """Get all devices."""

--- a/ring_doorbell/rtcstream.py
+++ b/ring_doorbell/rtcstream.py
@@ -1,0 +1,254 @@
+"""Python Ring Doorbell RTC Stream handler.
+
+This module is currently experimental and requires a webrtc enabled client
+to function.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import ssl
+import uuid
+from json import dumps as json_dumps
+from json import loads as json_loads
+from typing import TYPE_CHECKING, Any
+
+from websockets.client import connect
+
+from ring_doorbell.const import (
+    APP_API_URI,
+    RTC_STREAMING_TICKET_ENDPOINT,
+    RTC_STREAMING_WEB_SOCKET_ENDPOINT,
+)
+from ring_doorbell.exceptions import RingError
+
+if TYPE_CHECKING:
+    from websockets import WebSocketClientProtocol
+
+    from .ring import Ring
+
+_LOGGER = logging.getLogger(__name__)
+
+ICE_CANDIDATE_COLLECTION_SECONDS = 1
+
+
+class RingWebRtcStream:
+    """Class to handle a Web RTC Stream."""
+
+    def __init__(self, ring: Ring, device_api_id: int) -> None:
+        """Initialise the class."""
+        self._ring = ring
+        self.device_api_id = device_api_id
+        self.sdp: str | None = None
+        self.websocket: WebSocketClientProtocol | None = None
+        self.do_ping = False
+        self.ping_task: asyncio.Task | None = None
+        self.read_task: asyncio.Task | None = None
+        self.ice_candidates: dict[int, list[str]] = {0: [], 1: [], 2: [], 3: []}
+        self.collect_ice_candidates = False
+        self.ssl_context: ssl.SSLContext | None = None
+
+    async def generate(self, sdp_offer: str) -> str:
+        """Generate the RTC stream."""
+        self.collect_ice_candidates = True
+        self.do_ping = True
+
+        try:
+            _LOGGER.debug("Generating stream with sdp offer: %s", sdp_offer)
+            req = await self._ring.async_query(
+                RTC_STREAMING_TICKET_ENDPOINT,
+                method="POST",
+                base_uri=APP_API_URI,
+            )
+            ticket = req.json()["ticket"]
+
+            _LOGGER.debug(
+                "Received RTC streaming ticket from endpoint, creating websocket"
+            )
+            ws_uri = RTC_STREAMING_WEB_SOCKET_ENDPOINT.format(uuid.uuid4(), ticket)
+            loop = asyncio.get_running_loop()
+
+            if not self.ssl_context:
+                # create_default_context() blocks the event loop
+                self.ssl_context = await loop.run_in_executor(
+                    None, ssl.create_default_context
+                )
+            self.websocket = await connect(
+                ws_uri,
+                user_agent_header="android:com.ringapp",
+                ssl=self.ssl_context,
+            )
+
+            self.dialog_id = str(uuid.uuid4())
+            msg = {
+                "method": "live_view",
+                "dialog_id": self.dialog_id,
+                "body": {
+                    "doorbot_id": self.device_api_id,
+                    "stream_options": {"audio_enabled": True, "video_enabled": True},
+                    "sdp": sdp_offer,
+                    "type": "offer",
+                },
+            }
+            _LOGGER.debug(
+                "Connected to RTC streaming websocket, sending live_view message: %s",
+                msg,
+            )
+            await self.websocket.send(json_dumps(msg))
+
+            message = await self.websocket.recv()
+            if TYPE_CHECKING:
+                assert isinstance(message, str)
+
+            # Should be session created message
+            await self.handle_message(message)
+
+            message2 = await self.websocket.recv()
+            if TYPE_CHECKING:
+                assert isinstance(message2, str)
+            # Should be sdp answer message
+            await self.handle_message(message2)
+
+            activate_msg = self.get_session_message("activate_session", {})
+            _LOGGER.debug("Sending activate_session message: %s", activate_msg)
+            await self.websocket.send(json_dumps(activate_msg))
+
+            options_msg = self.get_session_message(
+                "stream_options", {"video_enabled": True, "audio_enabled": True}
+            )
+            _LOGGER.debug("Sending stream_options message: %s", options_msg)
+            await self.websocket.send(json_dumps(options_msg))
+
+            _LOGGER.debug("Starting ping and reader tasks")
+            self.ping_task = asyncio.create_task(self.pinger())
+            self.read_task = asyncio.create_task(self.reader())
+
+            _LOGGER.debug(
+                "Waiting %s seconds for ice candidates",
+                ICE_CANDIDATE_COLLECTION_SECONDS,
+            )
+            await asyncio.sleep(ICE_CANDIDATE_COLLECTION_SECONDS)
+            self.insert_ice_candidates()
+        except Exception as ex:
+            exmsg = "Error generating RTC stream"
+            raise RingError(exmsg, ex) from ex
+
+        if not self.sdp:
+            exmsg = "Unable to generate RTC stream in time"
+            raise RingError(exmsg)
+        _LOGGER.debug("Returning SDP answer: %s", self.sdp)
+        return self.sdp
+
+    async def close(self) -> None:
+        """Close the rtc stream."""
+        _LOGGER.debug("Closing the RTC Stream")
+        self.do_ping = False
+        if self.ping_task and not self.ping_task.done():
+            self.ping_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self.ping_task
+            self.ping_task = None
+        if self.websocket:
+            await self.websocket.close()
+            self.websocket = None
+        if self.read_task and not self.read_task.done():
+            await self.read_task
+            self.read_task = None
+
+    def get_session_message(self, method: str, body: dict[str, Any]) -> dict[str, Any]:
+        """Get a message to send to the session."""
+        return {
+            "method": method,
+            "dialog_id": self.dialog_id,
+            "body": {
+                **body,
+                "doorbot_id": self.device_api_id,
+                "session_id": self.session_id,
+            },
+        }
+
+    async def reader(self) -> None:
+        """Read messages from the websocket."""
+        if TYPE_CHECKING:
+            assert self.websocket
+        async for message in self.websocket:
+            if TYPE_CHECKING:
+                assert isinstance(message, str)
+            await self.handle_message(message)
+
+    async def pinger(self) -> None:
+        """Ping to keep the session alive."""
+        if TYPE_CHECKING:
+            assert self.websocket
+        while self.do_ping:
+            await asyncio.sleep(3)
+            ping = self.get_session_message("ping", {})
+            await self.websocket.send(json_dumps(ping))
+
+    def handle_ice_message(self, ice_candidate: str, multi_line_index: int) -> None:
+        """Handle an ice candidate message."""
+        _LOGGER.debug(
+            "Ice candidate received, multi_line_index: %s candidate: %s",
+            multi_line_index,
+            ice_candidate,
+        )
+        if self.collect_ice_candidates:
+            self.ice_candidates[int(multi_line_index)].append(ice_candidate)
+
+    def insert_ice_candidates(self) -> None:
+        """Insert an ice candidate into the sdp answer.
+
+        In 2023 the ring api did not return the ice servers in the sdp answer
+        and they had to be added as they were received on the web socket.
+        As of Sep 2024 they are coming back with the initial sdp answer.
+        """
+        if TYPE_CHECKING:
+            assert self.sdp
+        _LOGGER.debug("Inserting ICE candidates into sdp answer")
+        self.collect_ice_candidates = False
+        for line_index, candidates in self.ice_candidates.items():
+            if not candidates:
+                continue
+            candidates_dict = {
+                int(candidate[10:12]): f"a={candidate}\r\n" for candidate in candidates
+            }
+            candidates_text = ("").join(dict(sorted(candidates_dict.items())).values())
+            multi_text = f"a=mid:{line_index}"
+            self.sdp = self.sdp.replace(multi_text, candidates_text + multi_text)
+
+    async def handle_message(self, message_str: str) -> None:
+        """Handle a message from the web socket."""
+        if TYPE_CHECKING:
+            assert self.websocket
+        message = json_loads(message_str)
+        method = message["method"]
+        if method == "ice":
+            self.handle_ice_message(
+                message["body"]["ice"], message["body"]["mlineindex"]
+            )
+        elif method == "sdp":
+            sdp = message["body"]["sdp"]
+            self.sdp = sdp
+            _LOGGER.debug("SDP answer received: %s", sdp)
+        elif method == "notification":
+            text = message["body"]["text"]
+            _LOGGER.debug("Notification received: %s", text)
+            if text == "camera_connected":
+                camera_options = self.get_session_message(
+                    "camera_options", {"stealth_mode": False}
+                )
+                _LOGGER.debug("Sending camera options: %s", camera_options)
+                await self.websocket.send(json_dumps(camera_options))
+        elif method == "session_created":
+            self.session_id = message["body"]["session_id"]
+            _LOGGER.debug(
+                "Session created: %s___%s", self.session_id[:16], self.session_id[-16:]
+            )
+        elif method == "close":
+            _LOGGER.debug("Close: %s", str(message["body"]["reason"]))
+            self.do_ping = False
+            await self.websocket.close()
+        else:
+            _LOGGER.debug("Message received with method: %s", method)


### PR DESCRIPTION
This PR lets the api start a webrtc streaming session. Requires a client that supports the webrtc protocol and can generate the sdp offer.

This should be considered experimental functionality until added to the docs.