### PR TITLE
Fix method to enable in-home doorbell chime

### DIFF
--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -180,6 +180,7 @@ BEAM_KINDS = ["beams_ct200_transformer"]
 INTERCOM_KINDS = ["intercom_handset_audio"]
 
 # error strings
+MSG_BOOLEAN_REQUIRED = "Boolean value is required."
 MSG_EXISTING_TYPE = f"Integer value where {DOORBELL_EXISTING_TYPE}."
 MSG_GENERIC_FAIL = "Sorry.. Something went wrong..."
 FILE_EXISTS = "The file {0} already exists."

--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -38,7 +38,6 @@ class RingCapability(Enum):
     OPEN = auto()
     KNOCK = auto()
     PRE_ROLL = auto()
-    DING = auto()
 
     @staticmethod
     def from_name(name: str) -> RingCapability:
@@ -73,10 +72,7 @@ NAMESPACE_UUID = "379378b0-f747-4b67-a10f-3b13327e8879"
 
 DEFAULT_LISTEN_EVENT_EXPIRES_IN = 180
 # for Ring android app.  703521446232 for ring-site
-FCM_RING_SENDER_ID = "876313859327"
-FCM_API_KEY = "AIzaSyCv-hdFBmmdBBJadNy-TFwB-xN_H5m3Bk8"
-FCM_PROJECT_ID = "ring-17770"
-FCM_APP_ID = "1:876313859327:android:e10ec6ddb3c81f39"
+RING_SENDER_ID = 876313859327
 
 CLI_TOKEN_FILE = "ring_token.cache"  # noqa: S105
 GCM_TOKEN_FILE = "ring_gcm_token.cache"  # noqa: S105
@@ -116,11 +112,6 @@ INTERCOM_ALLOWED_USERS = LOCATIONS_ENDPOINT + "/users"
 KIND_DING = "ding"
 KIND_MOTION = "motion"
 KIND_INTERCOM_UNLOCK = "intercom_unlock"
-KIND_ALARM_MODE_NONE = "alarm_mode_none"
-KIND_ALARM_MODE_SOME = "alarm_mode_some"
-KIND_ALARM_SIREN = "alarm_siren"
-KIND_ALARM_SILENCED = "alarm_silenced"
-
 # chime test sound kinds
 CHIME_TEST_SOUND_KINDS = (KIND_DING, KIND_MOTION)
 
@@ -180,7 +171,6 @@ BEAM_KINDS = ["beams_ct200_transformer"]
 INTERCOM_KINDS = ["intercom_handset_audio"]
 
 # error strings
-MSG_BOOLEAN_REQUIRED = "Boolean value is required."
 MSG_EXISTING_TYPE = f"Integer value where {DOORBELL_EXISTING_TYPE}."
 MSG_GENERIC_FAIL = "Sorry.. Something went wrong..."
 FILE_EXISTS = "The file {0} already exists."
@@ -191,19 +181,6 @@ MSG_EXPECTED_ATTRIBUTE_NOT_FOUND = "Couldn't find expected attribute: {0}."
 PUSH_ACTION_DING = "com.ring.push.HANDLE_NEW_DING"
 PUSH_ACTION_MOTION = "com.ring.push.HANDLE_NEW_motion"
 PUSH_ACTION_INTERCOM_UNLOCK = "com.ring.push.INTERCOM_UNLOCK_FROM_APP"
-
-PUSH_NOTIFICATION_KINDS = {
-    PUSH_ACTION_DING: KIND_DING,  # legacy
-    "com.ring.pn.live-event.ding": KIND_DING,
-    PUSH_ACTION_MOTION: KIND_MOTION,  # legacy
-    "com.ring.pn.live-event.motion": KIND_MOTION,
-    "com.ring.pn.live-event.intercom": KIND_DING,
-    PUSH_ACTION_INTERCOM_UNLOCK: KIND_INTERCOM_UNLOCK,
-    "com.ring.push.HANDLE_NEW_SECURITY_PANEL_MODE_NONE_NOTICE": KIND_ALARM_MODE_NONE,
-    "com.ring.push.HANDLE_NEW_SECURITY_PANEL_MODE_SOME_NOTICE": KIND_ALARM_MODE_SOME,
-    "com.ring.push.HANDLE_NEW_USER_SOUND_SIREN": KIND_ALARM_SIREN,
-    "com.ring.push.HANDLE_NEW_NON_ALARM_SIREN_SILENCED": KIND_ALARM_SILENCED,
-}
 
 POST_DATA_JSON = {
     "api_version": API_VERSION,

--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -180,7 +180,6 @@ BEAM_KINDS = ["beams_ct200_transformer"]
 INTERCOM_KINDS = ["intercom_handset_audio"]
 
 # error strings
-MSG_BOOLEAN_REQUIRED = "Boolean value is required."
 MSG_EXISTING_TYPE = f"Integer value where {DOORBELL_EXISTING_TYPE}."
 MSG_GENERIC_FAIL = "Sorry.. Something went wrong..."
 FILE_EXISTS = "The file {0} already exists."

--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -38,6 +38,7 @@ class RingCapability(Enum):
     OPEN = auto()
     KNOCK = auto()
     PRE_ROLL = auto()
+    DING = auto()
 
     @staticmethod
     def from_name(name: str) -> RingCapability:
@@ -72,7 +73,10 @@ NAMESPACE_UUID = "379378b0-f747-4b67-a10f-3b13327e8879"
 
 DEFAULT_LISTEN_EVENT_EXPIRES_IN = 180
 # for Ring android app.  703521446232 for ring-site
-RING_SENDER_ID = 876313859327
+FCM_RING_SENDER_ID = "876313859327"
+FCM_API_KEY = "AIzaSyCv-hdFBmmdBBJadNy-TFwB-xN_H5m3Bk8"
+FCM_PROJECT_ID = "ring-17770"
+FCM_APP_ID = "1:876313859327:android:e10ec6ddb3c81f39"
 
 CLI_TOKEN_FILE = "ring_token.cache"  # noqa: S105
 GCM_TOKEN_FILE = "ring_gcm_token.cache"  # noqa: S105
@@ -112,6 +116,11 @@ INTERCOM_ALLOWED_USERS = LOCATIONS_ENDPOINT + "/users"
 KIND_DING = "ding"
 KIND_MOTION = "motion"
 KIND_INTERCOM_UNLOCK = "intercom_unlock"
+KIND_ALARM_MODE_NONE = "alarm_mode_none"
+KIND_ALARM_MODE_SOME = "alarm_mode_some"
+KIND_ALARM_SIREN = "alarm_siren"
+KIND_ALARM_SILENCED = "alarm_silenced"
+
 # chime test sound kinds
 CHIME_TEST_SOUND_KINDS = (KIND_DING, KIND_MOTION)
 
@@ -171,6 +180,7 @@ BEAM_KINDS = ["beams_ct200_transformer"]
 INTERCOM_KINDS = ["intercom_handset_audio"]
 
 # error strings
+MSG_BOOLEAN_REQUIRED = "Boolean value is required."
 MSG_EXISTING_TYPE = f"Integer value where {DOORBELL_EXISTING_TYPE}."
 MSG_GENERIC_FAIL = "Sorry.. Something went wrong..."
 FILE_EXISTS = "The file {0} already exists."
@@ -181,6 +191,19 @@ MSG_EXPECTED_ATTRIBUTE_NOT_FOUND = "Couldn't find expected attribute: {0}."
 PUSH_ACTION_DING = "com.ring.push.HANDLE_NEW_DING"
 PUSH_ACTION_MOTION = "com.ring.push.HANDLE_NEW_motion"
 PUSH_ACTION_INTERCOM_UNLOCK = "com.ring.push.INTERCOM_UNLOCK_FROM_APP"
+
+PUSH_NOTIFICATION_KINDS = {
+    PUSH_ACTION_DING: KIND_DING,  # legacy
+    "com.ring.pn.live-event.ding": KIND_DING,
+    PUSH_ACTION_MOTION: KIND_MOTION,  # legacy
+    "com.ring.pn.live-event.motion": KIND_MOTION,
+    "com.ring.pn.live-event.intercom": KIND_DING,
+    PUSH_ACTION_INTERCOM_UNLOCK: KIND_INTERCOM_UNLOCK,
+    "com.ring.push.HANDLE_NEW_SECURITY_PANEL_MODE_NONE_NOTICE": KIND_ALARM_MODE_NONE,
+    "com.ring.push.HANDLE_NEW_SECURITY_PANEL_MODE_SOME_NOTICE": KIND_ALARM_MODE_SOME,
+    "com.ring.push.HANDLE_NEW_USER_SOUND_SIREN": KIND_ALARM_SIREN,
+    "com.ring.push.HANDLE_NEW_NON_ALARM_SIREN_SILENCED": KIND_ALARM_SILENCED,
+}
 
 POST_DATA_JSON = {
     "api_version": API_VERSION,

--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -215,8 +215,10 @@ class RingDoorBell(RingGeneric):
 
     async def async_set_existing_doorbell_type_enabled(self, value: int) -> None:
         """Enable/disable the existing doorbell if Digital/Mechanical.
+
         0: Off
         1: On
+        
         """
 
         if self.existing_doorbell_type:

--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -32,6 +32,7 @@ from ring_doorbell.const import (
     HEALTH_DOORBELL_ENDPOINT,
     LIVE_STREAMING_ENDPOINT,
     MSG_ALLOWED_VALUES,
+    MSG_BOOLEAN_REQUIRED,
     MSG_EXISTING_TYPE,
     MSG_EXPECTED_ATTRIBUTE_NOT_FOUND,
     MSG_VOL_OUTBOUND,
@@ -213,23 +214,21 @@ class RingDoorBell(RingGeneric):
             return self._get_chime_setting("enable")
         return False
 
-    async def async_set_existing_doorbell_type_enabled(self, value: int) -> None:
-        """Enable/disable the existing doorbell if Digital/Mechanical.
-
-        0: Off
-        1: On
-        
-        """
-
+    async def async_set_existing_doorbell_type_enabled(self, value: bool) -> None:  # noqa: FBT001
+        """Enable/disable the existing doorbell if Digital/Mechanical."""
         if self.existing_doorbell_type:
+            if not isinstance(value, bool):
+                raise RingError(MSG_BOOLEAN_REQUIRED)
 
             if self.existing_doorbell_type == DOORBELL_EXISTING_TYPE[2]:
-                msg = f"In-Home chime is not present."
+                msg = "In-Home chime is not present."
                 raise RingError(msg)
+
+            int_value = int(value)
 
             params = {
                 "doorbot[description]": self.name,
-                "doorbot[settings][chime_settings][enable]": value,
+                "doorbot[settings][chime_settings][enable]": int_value,
             }
             url = DOORBELLS_ENDPOINT.format(self.device_api_id)
             await self._ring.async_query(url, extra_params=params, method="PUT")

--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -32,7 +32,6 @@ from ring_doorbell.const import (
     HEALTH_DOORBELL_ENDPOINT,
     LIVE_STREAMING_ENDPOINT,
     MSG_ALLOWED_VALUES,
-    MSG_BOOLEAN_REQUIRED,
     MSG_EXISTING_TYPE,
     MSG_EXPECTED_ATTRIBUTE_NOT_FOUND,
     MSG_VOL_OUTBOUND,
@@ -214,14 +213,17 @@ class RingDoorBell(RingGeneric):
             return self._get_chime_setting("enable")
         return False
 
-    async def async_set_existing_doorbell_type_enabled(self, value: bool) -> None:  # noqa: FBT001
-        """Enable/disable the existing doorbell if Digital/Mechanical."""
+    async def async_set_existing_doorbell_type_enabled(self, value: int) -> None:
+        """Enable/disable the existing doorbell if Digital/Mechanical.
+        0: Off
+        1: On
+        """
+
         if self.existing_doorbell_type:
-            if not isinstance(value, bool):
-                raise RingError(MSG_BOOLEAN_REQUIRED)
 
             if self.existing_doorbell_type == DOORBELL_EXISTING_TYPE[2]:
-                return
+                msg = f"In-Home chime is not present."
+                raise RingError(msg)
 
             params = {
                 "doorbot[description]": self.name,

--- a/tests/test_ring.py
+++ b/tests/test_ring.py
@@ -289,3 +289,15 @@ def test_sync_queries_with_no_event_loop():
 
     with pytest.deprecated_call():
         auth.close()
+
+
+async def test_async_set_existing_doorbell_type_enabled(ring):
+    data = ring.devices()
+    dev = data["doorbots"][0]
+    assert dev.existing_doorbell_type == "Mechanical"
+
+    # Attempting to torn off the in-home chime
+    await dev.async_set_existing_doorbell_type_enabled(value=False)
+
+    # Attempting to torn on the in-home chime
+    await dev.async_set_existing_doorbell_type_enabled(value=True)

--- a/tests/test_ring.py
+++ b/tests/test_ring.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 import pytest
 from freezegun.api import FrozenDateTimeFactory
 from ring_doorbell import Auth, Ring, RingError
-from ring_doorbell.const import USER_AGENT
+from ring_doorbell.const import MSG_EXISTING_TYPE, USER_AGENT
 from ring_doorbell.util import parse_datetime
 
 from .conftest import json_request_kwargs, load_fixture_as_dict, nojson_request_kwargs
@@ -291,13 +291,60 @@ def test_sync_queries_with_no_event_loop():
         auth.close()
 
 
-async def test_async_set_existing_doorbell_type_enabled(ring):
+async def test_set_existing_doorbell_type(ring, aioresponses_mock):
     data = ring.devices()
     dev = data["doorbots"][0]
     assert dev.existing_doorbell_type == "Mechanical"
 
-    # Attempting to torn off the in-home chime
-    await dev.async_set_existing_doorbell_type_enabled(value=False)
+    kwargs = nojson_request_kwargs()
 
-    # Attempting to torn on the in-home chime
+    aioresponses_mock.requests.clear()
+    # Attempting to turn off the in-home chime
+    await dev.async_set_existing_doorbell_type_enabled(value=False)
+    kwargs["params"] = {
+        "doorbot[description]": dev.name,
+        "doorbot[settings][chime_settings][enable]": 0,
+    }
+    aioresponses_mock.assert_called_with(
+        url="https://api.ring.com/clients_api/doorbots/987652",
+        method="PUT",
+        **kwargs,
+    )
+
+    aioresponses_mock.requests.clear()
+    # Attempting to turn on the in-home chime
     await dev.async_set_existing_doorbell_type_enabled(value=True)
+    kwargs["params"] = {
+        "doorbot[description]": dev.name,
+        "doorbot[settings][chime_settings][enable]": 1,
+    }
+    aioresponses_mock.assert_called_with(
+        url="https://api.ring.com/clients_api/doorbots/987652",
+        method="PUT",
+        **kwargs,
+    )
+
+    aioresponses_mock.requests.clear()
+    # Attempting to set the doorbell type
+    await dev.async_set_existing_doorbell_type(2)
+    kwargs["params"] = {
+        "doorbot[description]": dev.name,
+        "doorbot[settings][chime_settings][type]": 2,
+    }
+    aioresponses_mock.assert_called_with(
+        url="https://api.ring.com/clients_api/doorbots/987652",
+        method="PUT",
+        **kwargs,
+    )
+
+    # Attempting to enable when no chime present
+    settings = dev._attrs["settings"]["chime_settings"]
+    settings["type"] = 2
+    assert dev.existing_doorbell_type == "Not Present"
+
+    with pytest.raises(RingError, match="In-Home chime is not present."):
+        await dev.async_set_existing_doorbell_type_enabled(value=True)
+
+    # Attempting to set the doorbell type to an invalid value
+    with pytest.raises(RingError, match=f"value must be in {MSG_EXISTING_TYPE}"):
+        await dev.async_set_existing_doorbell_type(4)


### PR DESCRIPTION
I am currently working on adding code to the Home Assistant ring core component to support `async_set_existing_doorbell_type` and `async_set_existing_doorbell_type_enabled`. In working on the switch to enable/disable the in-home chime, I found that Ring is expecting a string, not a boolean value. Error below:

> ring_doorbell.exceptions.RingError: Unknown error during query of url https://api.ring.com/clients_api/doorbots/<doorbell id removed>: Invalid variable type: value should be str, int or float, got True of type <class 'bool'>

Ring is expecting 0 or 1 when enabling and disabling.  I have tested the code change with a modified test.py with the following body between `await ring.async_update_data()` and `await auth.async_close()`


```
    # Fetch all available doorbells
    devices = ring.devices()
    doorbells=devices['doorbots']

    # Flip the status of the in-home chime for each doorbell
    for doorbell in list(doorbells):
        await doorbell.async_update_health_data()
        print()
        print()
        print('Address:    %s' % doorbell.address)
        print('Family:     %s' % doorbell.family)
        print('ID:         %s' % doorbell.id)
        print('Name:       %s' % doorbell.name)
        print('In-Home Chime Type: %s' % doorbell.existing_doorbell_type)
        print('In-Home Chime Status: %s' % doorbell.existing_doorbell_type_enabled)
        print()
        print()
        if doorbell.existing_doorbell_type_enabled:
            print('Turning Off In-Home Chime')
            await doorbell.async_set_existing_doorbell_type_enabled(0)
            time.sleep(5)  # Pause for 5 seconds
        else:
            print('Turning On In-Home Chime')
            await doorbell.async_set_existing_doorbell_type_enabled(1)
            time.sleep(5)  # Pause for 5 seconds
        print()
        print()
        print('In-Home Chime Type: %s' % doorbell.existing_doorbell_type)
        print('In-Home Chime Status: %s' % doorbell.existing_doorbell_type_enabled)

```