### PR TITLE
Remove anyio from dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1995,4 +1995,4 @@ listen = ["firebase-messaging"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "9450ea4a06e2a82694cc6870f11bf3cdec977fc662d684d3f1e826f3890216a1"
+content-hash = "3ba1c88b5fb933f3cbdea18470a4fa2397e66759a5ea001347ee14f2e0e4294c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,9 @@ ring-doorbell = "ring_doorbell.cli:cli"
 python = "^3.9"
 oauthlib = ">=3.0.0,<4"
 pytz = ">=2022.0"
-asyncclick = ">=8"
+asyncclick = ">=8.1.7.1"
 aiohttp = ">=3"
 aiofiles = ">=23"
-anyio = "*" # see https://github.com/python-trio/asyncclick/issues/18
 sphinx = {version = "<7.2.6", optional = true}
 sphinx-rtd-theme = {version = "^1.3.0", optional = true}
 myst-parser = { version = "*", optional = true }


### PR DESCRIPTION
Asyncclick correctly specifies the dependency starting with version 8.1.7.1.