### PR TITLE
Fix in-home chime duration setter

### DIFF
--- a/ring_doorbell/const.py
+++ b/ring_doorbell/const.py
@@ -145,6 +145,9 @@ DOORBELL_EXISTING_TYPE = {0: "Mechanical", 1: "Digital", 2: "Not Present"}
 SIREN_DURATION_MIN = 0
 SIREN_DURATION_MAX = 120
 
+DOORBELL_EXISTING_DURATION_MIN = 0
+DOORBELL_EXISTING_DURATION_MAX = 10
+
 # device model kinds
 CHIME_KINDS = ["chime", "chime_v2"]
 CHIME_PRO_KINDS = ["chime_pro", "chime_pro_v2"]

--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -19,6 +19,8 @@ from ring_doorbell.const import (
     DOORBELL_3_PLUS_KINDS,
     DOORBELL_4_KINDS,
     DOORBELL_ELITE_KINDS,
+    DOORBELL_EXISTING_DURATION_MAX,
+    DOORBELL_EXISTING_DURATION_MIN,
     DOORBELL_EXISTING_TYPE,
     DOORBELL_GEN2_KINDS,
     DOORBELL_KINDS,
@@ -249,10 +251,16 @@ class RingDoorBell(RingGeneric):
         if self.existing_doorbell_type:
             if not (
                 (isinstance(value, int))
-                and (DOORBELL_VOL_MIN <= value <= DOORBELL_VOL_MAX)
+                and (
+                    DOORBELL_EXISTING_DURATION_MIN
+                    <= value
+                    <= DOORBELL_EXISTING_DURATION_MAX
+                )
             ):
                 raise RingError(
-                    MSG_VOL_OUTBOUND.format(DOORBELL_VOL_MIN, DOORBELL_VOL_MAX)
+                    MSG_VOL_OUTBOUND.format(
+                        DOORBELL_EXISTING_DURATION_MIN, DOORBELL_EXISTING_DURATION_MAX
+                    )
                 )
 
             if self.existing_doorbell_type == DOORBELL_EXISTING_TYPE[1]:

--- a/tests/test_ring.py
+++ b/tests/test_ring.py
@@ -337,6 +337,22 @@ async def test_set_existing_doorbell_type(ring, aioresponses_mock):
         **kwargs,
     )
 
+    aioresponses_mock.requests.clear()
+    # Attempting to set the duration of the in-home chime
+    settings = dev._attrs["settings"]["chime_settings"]
+    settings["type"] = 1
+    assert dev.existing_doorbell_type == "Digital"
+    await dev.async_set_existing_doorbell_type_duration(5)
+    kwargs["params"] = {
+        "doorbot[description]": dev.name,
+        "doorbot[settings][chime_settings][duration]": 5,
+    }
+    aioresponses_mock.assert_called_with(
+        url="https://api.ring.com/clients_api/doorbots/987652",
+        method="PUT",
+        **kwargs,
+    )
+
     # Attempting to enable when no chime present
     settings = dev._attrs["settings"]["chime_settings"]
     settings["type"] = 2
@@ -348,3 +364,7 @@ async def test_set_existing_doorbell_type(ring, aioresponses_mock):
     # Attempting to set the doorbell type to an invalid value
     with pytest.raises(RingError, match=f"value must be in {MSG_EXISTING_TYPE}"):
         await dev.async_set_existing_doorbell_type(4)
+
+    # Attempting to set the doorbell duration to an invalid value
+    with pytest.raises(RingError, match=f"Must be within the {0}-{1}."):
+        await dev.async_set_existing_doorbell_type_duration(11)


### PR DESCRIPTION
`async_set_existing_doorbell_type_duration` was checking for the duration to be between 0 and 11, but Ring only accepts 0 through 10 for duration.  I added a new set of min/max variables rather than using a different min/max set in order to allow more flexibility in the future.


Error from Ring when setting duration to 11:
```
ring_doorbell.exceptions.RingError: HTTP error with status code 422 during query of url https://api.ring.com/clients_api/doorbots/987652: 422, message='Unprocessable Entity', url='https://api.ring.com/clients_api/doorbots/987652?doorbot%5Bdescription%5D=Front+Door&doorbot%5Bsettings%5D%5Bchime_settings%5D%5Bduration%5D=11
```