### PR TITLE
Do not expose deprecated attributes to type checkers

### DIFF
--- a/ring_doorbell/auth.py
+++ b/ring_doorbell/auth.py
@@ -7,7 +7,7 @@ import uuid
 from asyncio import TimeoutError
 from functools import cached_property
 from json import loads as json_loads
-from typing import Any, Callable, ClassVar
+from typing import TYPE_CHECKING, Any, Callable, ClassVar
 
 from aiohttp import BasicAuth, ClientError, ClientResponseError, ClientSession
 from oauthlib.common import urldecode
@@ -268,9 +268,11 @@ class Auth:
         "query",
     }
 
-    def __getattr__(self, name: str) -> Any:
-        """Get a deprecated attribute or raise an error."""
-        if name in self.DEPRECATED_API_QUERIES:
-            return self._dep_handler.get_api_query(self, name)
-        msg = f"{self.__class__.__name__} has no attribute {name!r}"
-        raise AttributeError(msg)
+    if not TYPE_CHECKING:
+
+        def __getattr__(self, name: str) -> Any:
+            """Get a deprecated attribute or raise an error."""
+            if name in self.DEPRECATED_API_QUERIES:
+                return self._dep_handler.get_api_query(self, name)
+            msg = f"{self.__class__.__name__} has no attribute {name!r}"
+            raise AttributeError(msg)

--- a/ring_doorbell/cli.py
+++ b/ring_doorbell/cli.py
@@ -649,8 +649,8 @@ async def videos(
         not count
         and not download
         and not download_all
-        and device.last_recording_id
-        and (url := await device.async_recording_url(device.last_recording_id))
+        and (last_recording_id := await device.async_get_last_recording_id())
+        and (url := await device.async_recording_url(last_recording_id))
     ):
         echo("Last recording url is: " + url)
         return None

--- a/ring_doorbell/generic.py
+++ b/ring_doorbell/generic.py
@@ -248,18 +248,20 @@ class RingGeneric:
     DEPRECATED_API_PROPERTY_GETTERS: ClassVar[set[str]] = set()
     DEPRECATED_API_PROPERTY_SETTERS: ClassVar[set[str]] = set()
 
-    def __getattr__(self, name: str) -> Any:
-        """Get a deprecated attribute or raise an error."""
-        if name in self.DEPRECATED_API_QUERIES:
-            return self._ring.auth._dep_handler.get_api_query(self, name)  # noqa: SLF001
-        if name in self.DEPRECATED_API_PROPERTY_GETTERS:
-            return self._ring.auth._dep_handler.get_api_property(self, name)  # noqa: SLF001
-        msg = f"{self.__class__.__name__} has no attribute {name!r}"
-        raise AttributeError(msg)
+    if not TYPE_CHECKING:
 
-    def __setattr__(self, name: str, value: Any) -> None:
-        """Set a deprecated attribute or raise an error."""
-        if name in self.DEPRECATED_API_PROPERTY_SETTERS:
-            self._ring.auth._dep_handler.set_api_property(self, name, value)  # noqa: SLF001
-        else:
-            super().__setattr__(name, value)
+        def __getattr__(self, name: str) -> Any:
+            """Get a deprecated attribute or raise an error."""
+            if name in self.DEPRECATED_API_QUERIES:
+                return self._ring.auth._dep_handler.get_api_query(self, name)  # noqa: SLF001
+            if name in self.DEPRECATED_API_PROPERTY_GETTERS:
+                return self._ring.auth._dep_handler.get_api_property(self, name)  # noqa: SLF001
+            msg = f"{self.__class__.__name__} has no attribute {name!r}"
+            raise AttributeError(msg)
+
+        def __setattr__(self, name: str, value: Any) -> None:
+            """Set a deprecated attribute or raise an error."""
+            if name in self.DEPRECATED_API_PROPERTY_SETTERS:
+                self._ring.auth._dep_handler.set_api_property(self, name, value)  # noqa: SLF001
+            else:
+                super().__setattr__(name, value)

--- a/ring_doorbell/group.py
+++ b/ring_doorbell/group.py
@@ -128,16 +128,18 @@ class RingLightGroup:
         "lights",
     }
 
-    def __getattr__(self, name: str) -> Any:
-        """Get a deprecated attribute or raise an error."""
-        if name in self.DEPRECATED_API_QUERIES:
-            return self._ring.auth._dep_handler.get_api_query(self, name)  # noqa: SLF001
-        msg = f"{self.__class__.__name__} has no attribute {name!r}"
-        raise AttributeError(msg)
+    if not TYPE_CHECKING:
 
-    def __setattr__(self, name: str, value: Any) -> None:
-        """Set a deprecated attribute or raise an error."""
-        if name in self.DEPRECATED_API_PROPERTY_SETTERS:
-            self._ring.auth._dep_handler.set_api_property(self, name, value)  # noqa: SLF001
-        else:
-            super().__setattr__(name, value)
+        def __getattr__(self, name: str) -> Any:
+            """Get a deprecated attribute or raise an error."""
+            if name in self.DEPRECATED_API_QUERIES:
+                return self._ring.auth._dep_handler.get_api_query(self, name)  # noqa: SLF001
+            msg = f"{self.__class__.__name__} has no attribute {name!r}"
+            raise AttributeError(msg)
+
+        def __setattr__(self, name: str, value: Any) -> None:
+            """Set a deprecated attribute or raise an error."""
+            if name in self.DEPRECATED_API_PROPERTY_SETTERS:
+                self._ring.auth._dep_handler.set_api_property(self, name, value)  # noqa: SLF001
+            else:
+                super().__setattr__(name, value)

--- a/ring_doorbell/ring.py
+++ b/ring_doorbell/ring.py
@@ -292,12 +292,14 @@ class Ring:
         "query",
     }
 
-    def __getattr__(self, name: str) -> Any:
-        """Get a deprecated attribute or raise an error."""
-        if name in self.DEPRECATED_API_QUERIES:
-            return self.auth._dep_handler.get_api_query(self, name)  # noqa: SLF001
-        msg = f"{self.__class__.__name__} has no attribute {name!r}"
-        raise AttributeError(msg)
+    if not TYPE_CHECKING:
+
+        def __getattr__(self, name: str) -> Any:
+            """Get a deprecated attribute or raise an error."""
+            if name in self.DEPRECATED_API_QUERIES:
+                return self.auth._dep_handler.get_api_query(self, name)  # noqa: SLF001
+            msg = f"{self.__class__.__name__} has no attribute {name!r}"
+            raise AttributeError(msg)
 
 
 class RingDevices:


### PR DESCRIPTION
Consumers still using deprecate attributes will now start getting type checker errors.
