### PR TITLE
Do not refresh devices after calling setters

### DIFF
--- a/ring_doorbell/chime.py
+++ b/ring_doorbell/chime.py
@@ -75,7 +75,6 @@ class RingChime(RingGeneric):
         }
         url = CHIMES_ENDPOINT.format(self.device_api_id)
         await self._ring.async_query(url, extra_params=params, method="PUT")
-        await self._ring.async_update_devices()
 
     async def async_get_linked_tree(self) -> dict[str, Any]:
         """Return doorbell data linked to chime."""

--- a/ring_doorbell/cli.py
+++ b/ring_doorbell/cli.py
@@ -378,6 +378,7 @@ async def motion_detection(ctx, ring: Ring, device_name, turn_on, turn_off):
         return None
 
     await device.async_set_motion_detection(turn_on if turn_on else False)
+    await ring.async_update_devices()
     state = "on" if device.motion_detection else "off"
     echo(f"{device!s} motion detection set to {state}")
     return None

--- a/ring_doorbell/doorbot.py
+++ b/ring_doorbell/doorbot.py
@@ -208,7 +208,6 @@ class RingDoorBell(RingGeneric):
         if self.existing_doorbell_type:
             url = DOORBELLS_ENDPOINT.format(self.device_api_id)
             await self._ring.async_query(url, extra_params=params, method="PUT")
-            await self._ring.async_update_devices()
 
     @property
     def existing_doorbell_type_enabled(self) -> bool | None:
@@ -237,7 +236,6 @@ class RingDoorBell(RingGeneric):
             }
             url = DOORBELLS_ENDPOINT.format(self.device_api_id)
             await self._ring.async_query(url, extra_params=params, method="PUT")
-            await self._ring.async_update_devices()
 
     @property
     def existing_doorbell_type_duration(self) -> int | None:
@@ -273,7 +271,6 @@ class RingDoorBell(RingGeneric):
                 }
                 url = DOORBELLS_ENDPOINT.format(self.device_api_id)
                 await self._ring.async_query(url, extra_params=params, method="PUT")
-                await self._ring.async_update_devices()
 
     async def async_get_last_recording_id(self) -> int | None:
         """Return the last recording ID."""
@@ -388,7 +385,6 @@ class RingDoorBell(RingGeneric):
         }
         url = DOORBELLS_ENDPOINT.format(self.device_api_id)
         await self._ring.async_query(url, extra_params=params, method="PUT")
-        await self._ring.async_update_devices()
 
     @property
     def connection_status(self) -> str | None:
@@ -450,7 +446,6 @@ class RingDoorBell(RingGeneric):
         payload = {"motion_settings": {"motion_detection_enabled": state}}
 
         await self._ring.async_query(url, method="PATCH", json=payload)
-        await self._ring.async_update_devices()
 
     async def generate_webrtc_stream(
         self, sdp_offer: str, keep_alive_timeout: int | None = 30

--- a/ring_doorbell/listen/eventlistener.py
+++ b/ring_doorbell/listen/eventlistener.py
@@ -65,7 +65,6 @@ class RingEventListener:
         self._callbacks: dict[int, OnNotificationCallable] = {}
         self.subscribed = False
         self.started = False
-        self._app_id = self._ring.auth.get_hardware_id()
         self._device_model = self._ring.auth.get_device_model()
 
         self._credentials = credentials
@@ -166,6 +165,7 @@ class RingEventListener:
         timeout: int = 10,
     ) -> bool:
         """Start the listener."""
+        _logger.debug("Starting event listener")
         if not self._receiver:
             fcm_config = FcmRegisterConfig(
                 FCM_PROJECT_ID, FCM_APP_ID, FCM_API_KEY, FCM_RING_SENDER_ID
@@ -196,6 +196,7 @@ class RingEventListener:
             self.session_refresh_task = asyncio.create_task(
                 self._periodic_session_refresh()
             )
+            _logger.debug("Started event listener")
         return self.started
 
     async def _periodic_session_refresh(self) -> None:
@@ -276,8 +277,11 @@ class RingEventListener:
             ring_event = self._get_ring_event(msg_data)
 
         if ring_event:
+            _logger.debug("Event received %s", ring_event)
             for callback in self._callbacks.values():
                 callback(ring_event)
+        else:
+            _logger.debug("Unknown event received %s", msg_data)
 
     def _get_ring_event(self, msg_data: dict) -> RingEvent | None:
         if (android_config_str := msg_data.get("android_config")) is None or (

--- a/ring_doorbell/other.py
+++ b/ring_doorbell/other.py
@@ -137,7 +137,6 @@ class RingOther(RingGeneric):
         }
         url = DOORBELLS_ENDPOINT.format(self.device_api_id)
         await self._ring.async_query(url, extra_params=params, method="PUT")
-        await self._ring.async_update_devices()
 
     @property
     def keep_alive_auto(self) -> float | None:
@@ -152,7 +151,6 @@ class RingOther(RingGeneric):
         payload = {"keep_alive_settings": {"keep_alive_auto": value}}
 
         await self._ring.async_query(url, method="PATCH", json=payload)
-        await self._ring.async_update_devices()
 
     @property
     def mic_volume(self) -> int | None:
@@ -170,7 +168,6 @@ class RingOther(RingGeneric):
         payload = {"volume_settings": {"mic_volume": value}}
 
         await self._ring.async_query(url, method="PATCH", json=payload)
-        await self._ring.async_update_devices()
 
     @property
     def voice_volume(self) -> int | None:
@@ -188,7 +185,6 @@ class RingOther(RingGeneric):
         payload = {"volume_settings": {"voice_volume": value}}
 
         await self._ring.async_query(url, method="PATCH", json=payload)
-        await self._ring.async_update_devices()
 
     async def async_get_clip_length_max(self) -> int | None:
         """Get the Maximum clip length."""
@@ -206,7 +202,6 @@ class RingOther(RingGeneric):
         url = SETTINGS_ENDPOINT.format(self.device_api_id)
         payload = {"video_settings": {"clip_length_max": value}}
         await self._ring.async_query(url, method="PATCH", json=payload)
-        await self._ring.async_update_devices()
 
     @property
     def connection_status(self) -> str | None:
@@ -246,7 +241,6 @@ class RingOther(RingGeneric):
             }
             resp = await self._ring.async_query(url, method="PUT", json=payload)
             response = resp.json()
-            await self._ring.async_update_devices()
             if response.get("result", {}).get("code", -1) == 0:
                 return True
 

--- a/ring_doorbell/stickup_cam.py
+++ b/ring_doorbell/stickup_cam.py
@@ -150,7 +150,6 @@ class RingStickUpCam(RingDoorBell):
 
         url = LIGHTS_ENDPOINT.format(self.device_api_id, state)
         await self._ring.async_query(url, method="PUT")
-        await self._ring.async_update_devices()
 
     @property
     def siren(self) -> int:
@@ -177,7 +176,6 @@ class RingStickUpCam(RingDoorBell):
             params = {}
         url = SIREN_ENDPOINT.format(self.device_api_id, state)
         await self._ring.async_query(url, extra_params=params, method="PUT")
-        await self._ring.async_update_devices()
 
     DEPRECATED_API_PROPERTY_SETTERS: ClassVar = {
         *RingDoorBell.DEPRECATED_API_PROPERTY_SETTERS,


### PR DESCRIPTION
Consumers should call refresh devices themselves after calling setters. This allows consumers to control when they call `async_update_devices` in order to allow time for the device to return the new value correctly.