### PR TITLE
Fix 422 errors on PUT requests

### DIFF
--- a/ring_doorbell/auth.py
+++ b/ring_doorbell/auth.py
@@ -200,7 +200,8 @@ class Auth:
             "timeout": timeout,
         }
         headers = {"User-Agent": self.user_agent, "hardware_id": self.get_hardware_id()}
-        if json is not None:
+        # Ring servers started requiring a null json value for PUT requests in 2024-10
+        if json is not None or method == "PUT":
             kwargs["json"] = json
             headers["Content-Type"] = "application/json"
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -48,7 +48,8 @@ async def test_other_attributes(ring):
 async def test_other_controls(ring, aioresponses_mock):
     dev = ring.devices()["other"][0]
 
-    kwargs = nojson_request_kwargs()
+    kwargs = json_request_kwargs()
+    kwargs["json"] = None
 
     await dev.async_set_doorbell_volume(6)
     kwargs["params"] = {"doorbot[settings][doorbell_volume]": "6"}

--- a/tests/test_ring.py
+++ b/tests/test_ring.py
@@ -9,7 +9,7 @@ from ring_doorbell import Auth, Ring, RingError
 from ring_doorbell.const import MSG_EXISTING_TYPE, USER_AGENT
 from ring_doorbell.util import parse_datetime
 
-from .conftest import json_request_kwargs, load_fixture_as_dict, nojson_request_kwargs
+from .conftest import json_request_kwargs, load_fixture_as_dict
 
 
 def test_basic_attributes(ring):
@@ -116,7 +116,8 @@ def test_stickup_cam_attributes(ring):
 async def test_stickup_cam_controls(ring, aioresponses_mock):
     dev = ring.devices()["stickup_cams"][0]
 
-    kwargs = nojson_request_kwargs()
+    kwargs = json_request_kwargs()
+    kwargs["json"] = None
 
     await dev.async_set_lights("off")
     aioresponses_mock.assert_called_with(
@@ -296,7 +297,8 @@ async def test_set_existing_doorbell_type(ring, aioresponses_mock):
     dev = data["doorbots"][0]
     assert dev.existing_doorbell_type == "Mechanical"
 
-    kwargs = nojson_request_kwargs()
+    kwargs = json_request_kwargs()
+    kwargs["json"] = None
 
     aioresponses_mock.requests.clear()
     # Attempting to turn off the in-home chime


### PR DESCRIPTION
Ring servers suddenly required a null json value for `PUT` requests.