### PR TITLE
Add is_update flag to ring events for updated events

### DIFF
--- a/ring_doorbell/event.py
+++ b/ring_doorbell/event.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, NamedTuple
 
 
 @dataclass
@@ -18,6 +18,7 @@ class RingEvent:
     expires_in: float
     kind: str
     state: str
+    is_update: bool = False
 
     def __getitem__(self, key: str) -> Any:
         """Get a value by string."""
@@ -26,3 +27,19 @@ class RingEvent:
     def get(self, key: str) -> Any | None:
         """Get a value by string and return None if not present."""
         return getattr(self, key) if hasattr(self, key) else None
+
+    def get_key(self) -> RingEventKey:
+        """Return the identificationkey for the event."""
+        return RingEventKey(self.id, self.doorbot_id, self.kind, self.now)
+
+
+class RingEventKey(NamedTuple):
+    """Class to identify an event.
+
+    Used for determining if messages are updates to events.
+    """
+
+    id: int
+    doorbot_id: int
+    kind: str
+    now: float

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -263,7 +263,7 @@ async def test_listen_event_handler(mocker, auth):
         "2023-10-24 09:42:18.789709: RingEvent(id=12345678901234, "
         "doorbot_id=12345678, device_name='Front Floodcam'"
         ", device_kind='floodlight_v2', now=1698140538.789709,"
-        " expires_in=180, kind='motion', state='human') : "
+        " expires_in=180, kind='motion', state='human', is_update=False) : "
         "Currently active count = 1"
     )
     echomock.assert_called_with(exp)


### PR DESCRIPTION
Will enable consumers to filter out multiple events being raised by battery doorbells.
