### PR TITLE
Prepare 0.9.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.9.11](https://github.com/python-ring-doorbell/python-ring-doorbell/tree/0.9.11) (2024-11-12)
+
+[Full Changelog](https://github.com/python-ring-doorbell/python-ring-doorbell/compare/0.9.10...0.9.11)
+
+**Implemented enhancements:**
+
+- Add is\_update flag to ring events for updated events [\#467](https://github.com/python-ring-doorbell/python-ring-doorbell/pull/467) (@sdb9696)
+
 ## [0.9.10](https://github.com/python-ring-doorbell/python-ring-doorbell/tree/0.9.10) (2024-11-12)
 
 [Full Changelog](https://github.com/python-ring-doorbell/python-ring-doorbell/compare/0.9.9...0.9.10)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ring-doorbell"
-version = "0.9.10"
+version = "0.9.11"
 description = "A Python library to communicate with Ring Door Bell (https://ring.com/)"
 authors = [{ name = "python-ring-doorbell developers" }]
 license = { text="LGPL-3.0-or-later" }

--- a/uv.lock
+++ b/uv.lock
@@ -1334,7 +1334,7 @@ wheels = [
 
 [[package]]
 name = "ring-doorbell"
-version = "0.9.10"
+version = "0.9.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## [0.9.11](https://github.com/python-ring-doorbell/python-ring-doorbell/tree/0.9.11) (2024-11-12)

[Full Changelog](https://github.com/python-ring-doorbell/python-ring-doorbell/compare/0.9.10...0.9.11)

**Implemented enhancements:**

- Add is\_update flag to ring events for updated events [\#467](https://github.com/python-ring-doorbell/python-ring-doorbell/pull/467) (@sdb9696)