### PR TITLE
Prepare 0.9.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,26 @@
 # Changelog
 
-## [0.9.11](https://github.com/python-ring-doorbell/python-ring-doorbell/tree/0.9.11) (2024-11-12)
+## [0.9.12](https://github.com/python-ring-doorbell/python-ring-doorbell/tree/0.9.12) (2024-11-12)
 
-[Full Changelog](https://github.com/python-ring-doorbell/python-ring-doorbell/compare/0.9.10...0.9.11)
+[Full Changelog](https://github.com/python-ring-doorbell/python-ring-doorbell/compare/0.9.9...0.9.12)
+
+**Release highlights:**
+
+- Fix for Ring Elite motion and ding events
+- Add `is_update` to ring events to enable filtering duplicates
 
 **Implemented enhancements:**
 
 - Add is\_update flag to ring events for updated events [\#467](https://github.com/python-ring-doorbell/python-ring-doorbell/pull/467) (@sdb9696)
 
-## [0.9.10](https://github.com/python-ring-doorbell/python-ring-doorbell/tree/0.9.10) (2024-11-12)
-
-[Full Changelog](https://github.com/python-ring-doorbell/python-ring-doorbell/compare/0.9.9...0.9.10)
-
-**Release highlights:**
-
-- Fix for motion and ding alerts on Ring Elite
-
 **Fixed bugs:**
 
 - Add new push notification intercom unlock [\#464](https://github.com/python-ring-doorbell/python-ring-doorbell/pull/464) (@sdb9696)
 - Fix doorbell elite missing capabilities [\#463](https://github.com/python-ring-doorbell/python-ring-doorbell/pull/463) (@sdb9696)
+
+**Project maintenance:**
+
+- Update websockets dependency for \>=13 [\#469](https://github.com/python-ring-doorbell/python-ring-doorbell/pull/469) (@sdb9696)
 
 ## [0.9.9](https://github.com/python-ring-doorbell/python-ring-doorbell/tree/0.9.9) (2024-11-06)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ring-doorbell"
-version = "0.9.11"
+version = "0.9.12"
 description = "A Python library to communicate with Ring Door Bell (https://ring.com/)"
 authors = [{ name = "python-ring-doorbell developers" }]
 license = { text="LGPL-3.0-or-later" }

--- a/uv.lock
+++ b/uv.lock
@@ -1334,7 +1334,7 @@ wheels = [
 
 [[package]]
 name = "ring-doorbell"
-version = "0.9.11"
+version = "0.9.12"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## [0.9.12](https://github.com/python-ring-doorbell/python-ring-doorbell/tree/0.9.12) (2024-11-12)

[Full Changelog](https://github.com/python-ring-doorbell/python-ring-doorbell/compare/0.9.9...0.9.12)

**Release highlights:**

- Fix for Ring Elite motion and ding events
- Add `is_update` to ring events to enable filtering duplicates

**Implemented enhancements:**

- Add is\_update flag to ring events for updated events [\#467](https://github.com/python-ring-doorbell/python-ring-doorbell/pull/467) (@sdb9696)

**Fixed bugs:**

- Add new push notification intercom unlock [\#464](https://github.com/python-ring-doorbell/python-ring-doorbell/pull/464) (@sdb9696)
- Fix doorbell elite missing capabilities [\#463](https://github.com/python-ring-doorbell/python-ring-doorbell/pull/463) (@sdb9696)

**Project maintenance:**

- Update websockets dependency for \>=13 [\#469](https://github.com/python-ring-doorbell/python-ring-doorbell/pull/469) (@sdb9696)