### PR TITLE
Add WebRTC support for Ring Intercom Video

### DIFF
--- a/ring_doorbell/other.py
+++ b/ring_doorbell/other.py
@@ -28,6 +28,10 @@ from ring_doorbell.const import (
 )
 from ring_doorbell.exceptions import RingError
 from ring_doorbell.generic import RingGeneric
+from ring_doorbell.webrtcstream import (
+    RingWebRtcMessageCallback,
+    RingWebRtcStream,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,6 +46,7 @@ class RingOther(RingGeneric):
         """Initialise the other devices."""
         super().__init__(ring, device_api_id)
         self.shared = shared
+        self._webrtc_streams: dict[str, RingWebRtcStream] = {}
 
     @property
     def family(self) -> str:
@@ -75,6 +80,10 @@ class RingOther(RingGeneric):
             RingCapability.DING,
         ]:
             return self.kind in INTERCOM_KINDS
+
+        if capability == RingCapability.VIDEO:
+            return self.kind == "intercom_handset_video"
+
         return False
 
     @property
@@ -270,6 +279,52 @@ class RingOther(RingGeneric):
             return True
 
         return False
+
+    async def generate_async_webrtc_stream(
+        self,
+        sdp_offer: str,
+        session_id: str,
+        on_message_callback: RingWebRtcMessageCallback,
+        *,
+        keep_alive_timeout: int | None = 60 * 5,
+    ) -> None:
+        """Generate the rtc stream."""
+
+        async def _close_callback() -> None:
+            await self.close_webrtc_stream(session_id)
+
+        stream = RingWebRtcStream(
+            self._ring,
+            self.device_api_id,
+            on_message_callback=on_message_callback,
+            keep_alive_timeout=keep_alive_timeout,
+            on_close_callback=_close_callback,
+        )
+        self._webrtc_streams[session_id] = stream
+        await stream.generate(sdp_offer)
+
+    async def on_webrtc_candidate(
+        self, session_id: str, candidate: str, multi_line_index: int
+    ) -> None:
+        """Send an ICE candidate."""
+        if stream := self._webrtc_streams.get(session_id):
+            await stream.on_ice_candidate(candidate, multi_line_index)
+        else:
+            msg = "Ice candidate received before stream has been created."
+            raise RingError(msg)
+
+    async def close_webrtc_stream(self, session_id: str) -> None:
+        """Close the rtc stream."""
+        stream = self._webrtc_streams.pop(session_id, None)
+        if stream:
+            await stream.close()
+
+    def sync_close_webrtc_stream(self, session_id: str) -> None:
+        """Close the rtc stream."""
+        stream = self._webrtc_streams.pop(session_id, None)
+        if stream:
+            stream.sync_close()
+
 
     DEPRECATED_API_QUERIES: ClassVar = {
         *RingGeneric.DEPRECATED_API_QUERIES,

--- a/ring_doorbell/other.py
+++ b/ring_doorbell/other.py
@@ -8,12 +8,11 @@ import json
 import logging
 import time
 import uuid
-import aiofiles
 from typing import TYPE_CHECKING, Any, ClassVar
 
+import aiofiles
+
 from ring_doorbell.const import (
-    SNAPSHOT_ENDPOINT,
-    SNAPSHOT_TIMESTAMP_ENDPOINT,
     DOORBELLS_ENDPOINT,
     HEALTH_DOORBELL_ENDPOINT,
     INTERCOM_ALLOWED_USERS,
@@ -27,6 +26,8 @@ from ring_doorbell.const import (
     OTHER_DOORBELL_VOL_MAX,
     OTHER_DOORBELL_VOL_MIN,
     SETTINGS_ENDPOINT,
+    SNAPSHOT_ENDPOINT,
+    SNAPSHOT_TIMESTAMP_ENDPOINT,
     VOICE_VOL_MAX,
     VOICE_VOL_MIN,
     RingCapability,
@@ -362,7 +363,6 @@ class RingOther(RingGeneric):
         stream = self._webrtc_streams.pop(session_id, None)
         if stream:
             stream.sync_close()
-
 
     DEPRECATED_API_QUERIES: ClassVar = {
         *RingGeneric.DEPRECATED_API_QUERIES,

--- a/ring_doorbell/other.py
+++ b/ring_doorbell/other.py
@@ -3,12 +3,17 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+import time
 import uuid
+import aiofiles
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from ring_doorbell.const import (
+    SNAPSHOT_ENDPOINT,
+    SNAPSHOT_TIMESTAMP_ENDPOINT,
     DOORBELLS_ENDPOINT,
     HEALTH_DOORBELL_ENDPOINT,
     INTERCOM_ALLOWED_USERS,
@@ -114,6 +119,34 @@ class RingOther(RingGeneric):
         if self.kind in INTERCOM_KINDS and (features := self._attrs.get("features")):
             return features.get("show_recordings", False)
         return False
+
+async def async_get_snapshot(
+        self, retries: int = 3, delay: int = 1, filename: str | None = None
+    ) -> bytes | None:
+        """Take a snapshot and download it."""
+        payload = {"doorbot_ids": [self._attrs.get("id")]}
+        await self._ring.async_query(
+            SNAPSHOT_TIMESTAMP_ENDPOINT, method="POST", json=payload
+        )
+        request_time = time.time()
+        for _ in range(retries):
+            await asyncio.sleep(delay)
+            resp = await self._ring.async_query(
+                SNAPSHOT_TIMESTAMP_ENDPOINT, method="POST", json=payload
+            )
+            response = resp.json()
+            if response["timestamps"][0]["timestamp"] / 1000 > request_time:
+                resp = await self._ring.async_query(
+                    SNAPSHOT_ENDPOINT.format(self._attrs.get("id"))
+                )
+                snapshot = resp.content
+                if filename:
+                    async with aiofiles.open(filename, "wb") as jpg:
+                        await jpg.write(snapshot)
+                    return None
+                return snapshot
+
+        return None
 
     @property
     def unlock_duration(self) -> str | None:

--- a/ring_doorbell/other.py
+++ b/ring_doorbell/other.py
@@ -120,7 +120,7 @@ class RingOther(RingGeneric):
             return features.get("show_recordings", False)
         return False
 
-async def async_get_snapshot(
+    async def async_get_snapshot(
         self, retries: int = 3, delay: int = 1, filename: str | None = None
     ) -> bytes | None:
         """Take a snapshot and download it."""
@@ -135,7 +135,12 @@ async def async_get_snapshot(
                 SNAPSHOT_TIMESTAMP_ENDPOINT, method="POST", json=payload
             )
             response = resp.json()
-            if response["timestamps"][0]["timestamp"] / 1000 > request_time:
+            timestamps = response.get("timestamps") or []
+            if not timestamps:
+                continue
+
+            timestamp = timestamps[0].get("timestamp")
+            if timestamp is not None and timestamp / 1000 > request_time:
                 resp = await self._ring.async_query(
                     SNAPSHOT_ENDPOINT.format(self._attrs.get("id"))
                 )

--- a/ring_doorbell/ring.py
+++ b/ring_doorbell/ring.py
@@ -233,20 +233,11 @@ class Ring:
             else all_devices[api_id_to_idx[device_api_id]]
         )
 
-    def video_devices(self) -> Sequence[RingDoorBell | RingOther]:
-        """Get all video-capable devices."""
+    def video_devices(self) -> Sequence[RingDoorBell]:
+        """Get all devices."""
         devices = self.devices()
         return list(
-            chain(
-                devices.doorbots,
-                devices.authorized_doorbots,
-                devices.stickup_cams,
-                (
-                    device
-                    for device in devices.other
-                    if device.has_capability("video")
-                ),
-            )
+            chain(devices.doorbots, devices.authorized_doorbots, devices.stickup_cams)
         )
 
     def groups(self) -> Mapping[str, RingLightGroup]:
@@ -416,14 +407,9 @@ class RingDevices:
         return list(self._all_devices.values())
 
     @property
-    def video_devices(self) -> Sequence[RingDoorBell | RingOther]:
-        """The video devices, i.e. doorbells, stickup cams, and video intercoms."""
-        return [
-            *self._doorbots,
-            *self._authorized_doorbots,
-            *self._stickup_cams,
-            *(device for device in self._other if device.has_capability("video")),
-        ]
+    def video_devices(self) -> Sequence[RingDoorBell]:
+        """The video devices, i.e. doorbells and stickup_cams."""
+        return [*self._doorbots, *self._authorized_doorbots, *self._stickup_cams]
 
     def get_device(self, device_api_id: int) -> RingGeneric:
         """Get device by api id."""

--- a/ring_doorbell/ring.py
+++ b/ring_doorbell/ring.py
@@ -233,11 +233,20 @@ class Ring:
             else all_devices[api_id_to_idx[device_api_id]]
         )
 
-    def video_devices(self) -> Sequence[RingDoorBell]:
-        """Get all devices."""
+    def video_devices(self) -> Sequence[RingDoorBell | RingOther]:
+        """Get all video-capable devices."""
         devices = self.devices()
         return list(
-            chain(devices.doorbots, devices.authorized_doorbots, devices.stickup_cams)
+            chain(
+                devices.doorbots,
+                devices.authorized_doorbots,
+                devices.stickup_cams,
+                (
+                    device
+                    for device in devices.other
+                    if device.has_capability("video")
+                ),
+            )
         )
 
     def groups(self) -> Mapping[str, RingLightGroup]:
@@ -407,9 +416,14 @@ class RingDevices:
         return list(self._all_devices.values())
 
     @property
-    def video_devices(self) -> Sequence[RingDoorBell]:
-        """The video devices, i.e. doorbells and stickup_cams."""
-        return [*self._doorbots, *self._authorized_doorbots, *self._stickup_cams]
+    def video_devices(self) -> Sequence[RingDoorBell | RingOther]:
+        """The video devices, i.e. doorbells, stickup cams, and video intercoms."""
+        return [
+            *self._doorbots,
+            *self._authorized_doorbots,
+            *self._stickup_cams,
+            *(device for device in self._other if device.has_capability("video")),
+        ]
 
     def get_device(self, device_api_id: int) -> RingGeneric:
         """Get device by api id."""

--- a/ring_doorbell/webrtcstream.py
+++ b/ring_doorbell/webrtcstream.py
@@ -388,6 +388,8 @@ class RingWebRtcStream:
             await websocket.close()
         if read_task := self.read_task:
             self.read_task = None
+            if read_task is asyncio.current_task():
+                return
             if not read_task.done():
                 await read_task
 
@@ -413,7 +415,14 @@ class RingWebRtcStream:
             else:
                 _LOGGER.debug("Received notification: %s", message)
         elif method == "session_created":
-            self.session_id = message["body"]["session_id"]
+            body = message.get("body") or {}
+            if not (session_id := body.get("session_id")):
+                _LOGGER.warning(
+                    "Ignoring session_created without session_id (body keys: %s)",
+                    sorted(body),
+                )
+                return
+            self.session_id = session_id
             if TYPE_CHECKING:
                 assert self.session_id
             _LOGGER.debug(

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1,5 +1,7 @@
 """The tests for the Ring platform."""
 
+from unittest.mock import AsyncMock, MagicMock
+
 from .conftest import json_request_kwargs, nojson_request_kwargs
 
 
@@ -143,7 +145,9 @@ async def test_other_open_door(ring, aioresponses_mock, mocker):
         **kwargs,
     )
 
+
 async def test_intercom_video_webrtc_support(ring):
+    """Test WebRTC methods and video capability for a video intercom."""
     dev = ring.devices()["other"][0]
     dev._attrs["kind"] = "intercom_handset_video"
 
@@ -152,3 +156,19 @@ async def test_intercom_video_webrtc_support(ring):
     assert hasattr(dev, "on_webrtc_candidate")
     assert hasattr(dev, "close_webrtc_stream")
     assert hasattr(dev, "sync_close_webrtc_stream")
+
+
+async def test_intercom_snapshot_handles_empty_timestamps(ring, mocker):
+    """Test an empty Ring timestamp response does not raise an exception."""
+    dev = ring.devices()["other"][0]
+    empty_response = MagicMock()
+    empty_response.json.return_value = {"timestamps": []}
+    query = mocker.patch.object(
+        dev._ring,
+        "async_query",
+        new=AsyncMock(return_value=empty_response),
+    )
+    mocker.patch("ring_doorbell.other.asyncio.sleep", new=AsyncMock())
+
+    assert await dev.async_get_snapshot(retries=2, delay=0) is None
+    assert query.await_count == 3

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -142,3 +142,13 @@ async def test_other_open_door(ring, aioresponses_mock, mocker):
         method="PUT",
         **kwargs,
     )
+
+async def test_intercom_video_webrtc_support(ring):
+    dev = ring.devices()["other"][0]
+    dev._attrs["kind"] = "intercom_handset_video"
+
+    assert dev.has_capability("video") is True
+    assert hasattr(dev, "generate_async_webrtc_stream")
+    assert hasattr(dev, "on_webrtc_candidate")
+    assert hasattr(dev, "close_webrtc_stream")
+    assert hasattr(dev, "sync_close_webrtc_stream")

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2,6 +2,10 @@
 
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+from ring_doorbell.const import SNAPSHOT_ENDPOINT, SNAPSHOT_TIMESTAMP_ENDPOINT
+from ring_doorbell.exceptions import RingError
+
 from .conftest import json_request_kwargs, nojson_request_kwargs
 
 
@@ -179,6 +183,25 @@ async def test_intercom_video_webrtc_lifecycle(ring, mocker):
     assert "session" not in dev._webrtc_streams
 
 
+async def test_intercom_stream_close_callback_removes_session(ring, mocker):
+    """A remotely closed stream is removed and cannot receive more candidates."""
+    dev = ring.devices()["other"][0]
+    stream = MagicMock(generate=AsyncMock(), close=AsyncMock())
+    stream_type = mocker.patch(
+        "ring_doorbell.other.RingWebRtcStream", return_value=stream
+    )
+    await dev.generate_async_webrtc_stream("offer", "session", AsyncMock())
+
+    await stream_type.call_args.kwargs["on_close_callback"]()
+
+    assert "session" not in dev._webrtc_streams
+    stream.close.assert_awaited_once_with()
+    await dev.close_webrtc_stream("session")
+    stream.close.assert_awaited_once_with()
+    with pytest.raises(RingError, match="before stream has been created"):
+        await dev.on_webrtc_candidate("session", "candidate", 1)
+
+
 async def test_intercom_video_webrtc_sync_close(ring, mocker):
     """Test synchronously closing a video intercom WebRTC stream."""
     dev = ring.devices()["other"][0]
@@ -207,3 +230,52 @@ async def test_intercom_snapshot_handles_empty_timestamps(ring, mocker):
 
     assert await dev.async_get_snapshot(retries=2, delay=0) is None
     assert query.await_count == 3
+
+
+@pytest.mark.parametrize("save_to_file", [False, True], ids=["bytes", "file"])
+async def test_intercom_snapshot_downloads_only_fresh_image(
+    ring, mocker, tmp_path, save_to_file
+):
+    """Ignore stale timestamps and return or save the freshly downloaded image."""
+    dev = ring.devices()["other"][0]
+    dev._attrs["kind"] = "intercom_handset_video"
+    mocker.patch("ring_doorbell.other.time.time", return_value=100)
+    sleep = mocker.patch("ring_doorbell.other.asyncio.sleep", new=AsyncMock())
+    snapshot = b"fresh intercom snapshot"
+    query = mocker.patch.object(
+        dev._ring,
+        "async_query",
+        new=AsyncMock(
+            side_effect=[
+                MagicMock(),
+                MagicMock(json=MagicMock(return_value={"timestamps": []})),
+                MagicMock(json=MagicMock(return_value={"timestamps": [{}]})),
+                MagicMock(
+                    json=MagicMock(return_value={"timestamps": [{"timestamp": 100000}]})
+                ),
+                MagicMock(
+                    json=MagicMock(return_value={"timestamps": [{"timestamp": 101000}]})
+                ),
+                MagicMock(content=snapshot),
+            ]
+        ),
+    )
+    filename = tmp_path / "snapshot.jpg"
+
+    result = await dev.async_get_snapshot(
+        retries=4, delay=1, filename=str(filename) if save_to_file else None
+    )
+
+    assert result == (None if save_to_file else snapshot)
+    assert filename.exists() is save_to_file
+    if save_to_file:
+        assert filename.read_bytes() == snapshot
+    timestamp_call = mocker.call(
+        SNAPSHOT_TIMESTAMP_ENDPOINT,
+        method="POST",
+        json={"doorbot_ids": [dev.id]},
+    )
+    assert query.await_args_list == [timestamp_call] * 5 + [
+        mocker.call(SNAPSHOT_ENDPOINT.format(dev.id))
+    ]
+    assert sleep.await_args_list == [mocker.call(1)] * 4

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -146,16 +146,51 @@ async def test_other_open_door(ring, aioresponses_mock, mocker):
     )
 
 
-async def test_intercom_video_webrtc_support(ring):
-    """Test WebRTC methods and video capability for a video intercom."""
+async def test_intercom_video_webrtc_lifecycle(ring, mocker):
+    """Test creating, updating, and closing a video intercom WebRTC stream."""
     dev = ring.devices()["other"][0]
     dev._attrs["kind"] = "intercom_handset_video"
+    callback = AsyncMock()
+    stream = MagicMock()
+    stream.generate = AsyncMock()
+    stream.on_ice_candidate = AsyncMock()
+    stream.close = AsyncMock()
+    stream_type = mocker.patch(
+        "ring_doorbell.other.RingWebRtcStream", return_value=stream
+    )
 
     assert dev.has_capability("video") is True
-    assert hasattr(dev, "generate_async_webrtc_stream")
-    assert hasattr(dev, "on_webrtc_candidate")
-    assert hasattr(dev, "close_webrtc_stream")
-    assert hasattr(dev, "sync_close_webrtc_stream")
+
+    await dev.generate_async_webrtc_stream("offer", "session", callback)
+    stream_type.assert_called_once_with(
+        dev._ring,
+        dev.device_api_id,
+        on_message_callback=callback,
+        keep_alive_timeout=300,
+        on_close_callback=mocker.ANY,
+    )
+    stream.generate.assert_awaited_once_with("offer")
+
+    await dev.on_webrtc_candidate("session", "candidate", 2)
+    stream.on_ice_candidate.assert_awaited_once_with("candidate", 2)
+
+    await dev.close_webrtc_stream("session")
+    stream.close.assert_awaited_once_with()
+    assert "session" not in dev._webrtc_streams
+
+
+async def test_intercom_video_webrtc_sync_close(ring, mocker):
+    """Test synchronously closing a video intercom WebRTC stream."""
+    dev = ring.devices()["other"][0]
+    stream = MagicMock()
+    stream.generate = AsyncMock()
+    mocker.patch("ring_doorbell.other.RingWebRtcStream", return_value=stream)
+
+    await dev.generate_async_webrtc_stream("offer", "session", AsyncMock())
+    dev.sync_close_webrtc_stream("session")
+
+    stream.sync_close.assert_called_once_with()
+    assert "session" not in dev._webrtc_streams
 
 
 async def test_intercom_snapshot_handles_empty_timestamps(ring, mocker):

--- a/tests/test_webrtcstream.py
+++ b/tests/test_webrtcstream.py
@@ -1,0 +1,27 @@
+"""Tests for the Ring WebRTC stream handler."""
+
+import asyncio
+from unittest.mock import MagicMock
+
+from ring_doorbell.webrtcstream import RingWebRtcStream
+
+
+async def test_session_created_without_session_id_is_ignored(caplog):
+    """Test malformed session-created messages do not break the stream."""
+    stream = RingWebRtcStream(MagicMock(), 123)
+
+    await stream.handle_message('{"method":"session_created","body":{}}')
+
+    assert stream.session_id is None
+    assert "without session_id" in caplog.text
+
+
+async def test_close_from_reader_does_not_await_itself():
+    """Test closing from the reader task does not await the same task."""
+    stream = RingWebRtcStream(MagicMock(), 123)
+    stream.read_task = asyncio.current_task()
+
+    await stream._close(closed_by_self=False)
+
+    assert stream.read_task is None
+    assert stream.is_alive is False


### PR DESCRIPTION
Adds Ring Intercom Video support for video-capable `RingOther` devices.

This exposes the required snapshot and WebRTC APIs for intercom devices so Home Assistant can create a live-view camera entity for Ring Intercom Video devices.

Tested locally with a real Ring Intercom Video / Door setup:

- live video works
- snapshot retrieval works
- door open works
- hang up / close works

Related Home Assistant Core PR:
home-assistant/core#175136